### PR TITLE
Plutus 1.28

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ index-state:
   -- Bump both the following dates if you need newer packages from Hackage
   , hackage.haskell.org 2024-05-20T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-05-20T00:00:00Z
+  , cardano-haskell-packages 2024-05-29T00:00:00Z
 
 packages: 
   ./.

--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ repository cardano-haskell-packages
 
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
-  , hackage.haskell.org 2024-05-20T00:00:00Z
+  , hackage.haskell.org 2024-05-29T00:00:00Z
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2024-05-29T00:00:00Z
 

--- a/flake.lock
+++ b/flake.lock
@@ -237,24 +237,6 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -334,11 +316,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1716165244,
-        "narHash": "sha256-nLa5/uCdXT5Nq35EYbgz1hYTnwT70Sk/JInM2f1zg4c=",
+        "lastModified": 1717374384,
+        "narHash": "sha256-YD87yUa2RkcR4Cno49rvHqshdwijQyni4stTKMt1HME=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "980c35047cc64f93f4b15c0d3b2338fe18ffe97f",
+        "rev": "114e46a1de6c13d9dd2974aa076ea97d4557544f",
         "type": "github"
       },
       "original": {
@@ -389,11 +371,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1716166225,
-        "narHash": "sha256-gFMvOwooBevnHtZyGoiOcRes9ZSylG5YfNoqOHGdP/M=",
+        "lastModified": 1717375814,
+        "narHash": "sha256-9ZXVLVeL83slTJxSSGOdr6+zk+LgpDsUvbGDNrV1VZo=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6aa8046087d4e6fd70f3b6b99628f77e398e9fd2",
+        "rev": "61ebae6ae71b46206e5a951c9ca985ff720e856a",
         "type": "github"
       },
       "original": {
@@ -618,11 +600,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1716018802,
-        "narHash": "sha256-AZWYEAnN1mnTbX5pwhznfPBFSXnvxqHlDuoqdtwOVgQ=",
+        "lastModified": 1717416591,
+        "narHash": "sha256-Jnlu05hNRa7k0kf9P7GARx9T/mEQ/QXOcKfun/os5QM=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "37a2d712bdb7c109d103b1e0be6bdfa12d4d6a6a",
+        "rev": "8b8287675e43606a7f7030710b8ab14c2dc9f403",
         "type": "github"
       },
       "original": {
@@ -642,11 +624,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1714467508,
-        "narHash": "sha256-FuA0HPpBMHTgg/SNC+N5a6spj/O979IBpAJCfSkZL0Q=",
+        "lastModified": 1715898223,
+        "narHash": "sha256-G1LFsvP53twrqaC1FVard/6rjJJ3oitnpJ1E+mTZDGM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "89387f07016fe416c16f7824715238b3d1a4390a",
+        "rev": "29f19cd41dc593cf17bbc24194e34e7c20889fc9",
         "type": "github"
       },
       "original": {
@@ -658,11 +640,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1708894040,
-        "narHash": "sha256-Rv+PajrnuJ6AeyhtqzMN+bcR8z9+aEnrUass+N951CQ=",
+        "lastModified": 1710581758,
+        "narHash": "sha256-UNUXGiKLGUv1TuQumV70rfjCJERP4w8KZEDxsMG0RHc=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2f2a318fd8837f8063a0d91f329aeae29055fba9",
+        "rev": "50ea210590ab0519149bfd163d5ba199be925fb6",
         "type": "github"
       },
       "original": {
@@ -971,17 +953,16 @@
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_4",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1715850717,
-        "narHash": "sha256-HGY8w2Glb5xe4/l69Auv6R1kxbAQehB1vWFGnvzvSR8=",
+        "lastModified": 1716213921,
+        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "963646978438e31c0925e16c4eca089fda69bac2",
+        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
         "type": "github"
       },
       "original": {
@@ -1055,11 +1036,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1716164362,
-        "narHash": "sha256-BXJRk20IcsG8uhuLWxA0Lfzx6VVKNEGQ/TINDkd6MH0=",
+        "lastModified": 1717373514,
+        "narHash": "sha256-VZUBOQfRxelZAtrbYtapj4iU9Q+u2W0XxE4mMi2pGZg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "f27332e59a188f096a67a46fb5d33b0ea1d5a221",
+        "rev": "208ec4b8b78a0b81412eeed4a6ac2e4c1fb7210e",
         "type": "github"
       },
       "original": {
@@ -1099,21 +1080,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1715802876,
-        "narHash": "sha256-fy8xdNgFXJvX0UnW0HNdhcZA/n0FGomkshJExKUcjUs=",
+        "lastModified": 1716984675,
+        "narHash": "sha256-L1b3BCXhMe7UxXrBOUQuxHNeuhwSgq36YGvEd7Vvo9o=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "70c2100e4206788b082a836046a5133902a1ceb1",
+        "rev": "5e412d16eaa900deba068508b80fb7cceb055d9c",
         "type": "github"
       },
       "original": {

--- a/plutus-tx-template.cabal
+++ b/plutus-tx-template.cabal
@@ -17,10 +17,10 @@ executable plutus-tx-template
     , base
     , base16-bytestring
     , bytestring
-    , plutus-core ^>=1.27.0.0
-    , plutus-ledger-api ^>=1.27.0.0
-    , plutus-tx ^>=1.27.0.0
-    , plutus-tx-plugin ^>=1.27.0.0
+    , plutus-core        ^>=1.28
+    , plutus-ledger-api  ^>=1.28
+    , plutus-tx          ^>=1.28
+    , plutus-tx-plugin   ^>=1.28
     , text
     , time
 


### PR DESCRIPTION
I have this problem building dev shell after updating CHaP:

```
nix develop -L  
warning: Git tree '/home/yura/projects/cardano/plutus-tx-template' is dirty
plutus-tx-template-plan-to-nix-pkgs> Warning: The package list for 'hackage.haskell.org' is 19877 days old.
plutus-tx-template-plan-to-nix-pkgs> Run 'cabal update' to get the latest list of available packages.
plutus-tx-template-plan-to-nix-pkgs> Warning: Requested index-state 2024-06-03T00:00:00Z is newer than
plutus-tx-template-plan-to-nix-pkgs> 'hackage.haskell.org'! Falling back to older state (2024-06-02T23:45:05Z).
plutus-tx-template-plan-to-nix-pkgs> Warning: The package list for 'cardano-haskell-packages' is 19877 days old.
plutus-tx-template-plan-to-nix-pkgs> Run 'cabal update' to get the latest list of available packages.
plutus-tx-template-plan-to-nix-pkgs> Warning: Requested index-state 2024-05-29T00:00:00Z is newer than
plutus-tx-template-plan-to-nix-pkgs> 'cardano-haskell-packages'! Falling back to older state
plutus-tx-template-plan-to-nix-pkgs> (2024-05-24T09:29:56Z).
plutus-tx-template-plan-to-nix-pkgs> Resolving dependencies...
plutus-tx-template-plan-to-nix-pkgs> Writing plan.json to /build/tmp.48QGsuabjx/dist-newstyle/cache/plan.json
plutus-tx-template-plan-to-nix-pkgs> Wrote freeze file to /build/tmp.48QGsuabjx/cabal.project.freeze
plutus-tx-template-plan-to-nix-pkgs> Writing cabal files to /build/tmp.48QGsuabjx/dist-newstyle/cabal-files
plutus-tx-template-plan-to-nix-pkgs> Moving cabal files from /build/tmp.48QGsuabjx/dist-newstyle/cabal-files to /nix/store/xxx3vyh2s30jc6v90ccc39xgb0z1730q-plutus-tx-template-plan-to-nix-pkgs/cabal-files
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:9:12:
            8|
            9|   strict = derivationStrict drvAttrs;
             |            ^
           10|

       … while evaluating derivation 'ghc-shell-for-plutus-tx-template'
         whose name attribute is located at /nix/store/apn339kmg5xllk224ghr7cw6468pgkc7-source/pkgs/stdenv/generic/make-derivation.nix:300:7

       … while evaluating attribute 'NIX_GHC_LIBDIR' of derivation 'ghc-shell-for-plutus-tx-template'
         at /nix/store/jlqhijv6r1hj0h3bm5m6byraa0khqmi9-source/builder/shell-for.nix:197:5:
          196|     # the correct global package DB.
          197|     NIX_GHC_LIBDIR = ghcEnv.drv + "/" + configFiles.libDir;
             |     ^
          198|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Dependency is not of a valid type: element 3 of buildInputs for ghc-9.6.5-setup
```

this looks like a `haskell.nix` problem to me. @zeme-wana please advise.