### PR TITLE
Update index states.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,9 +11,9 @@ repository cardano-haskell-packages
 
 index-state:
   -- Bump both the following dates if you need newer packages from Hackage
-  , hackage.haskell.org 2024-12-12T00:00:00Z
+  , hackage.haskell.org 2025-01-27T17:45:32Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-12-12T00:00:00Z
+  , cardano-haskell-packages 2025-01-22T23:05:02Z
 
 packages:
   ./.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1733946732,
-        "narHash": "sha256-8RwIGx4z0LELkL5d8Xg85/O5yqox6mHtusrNoIqSeCU=",
+        "lastModified": 1737590273,
+        "narHash": "sha256-zzeaIeeKCVfTxeSLw3oTmguOwH46NJw5LZH8wyWbATQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "6d857b7864e15267825582b785a6b1ce71942c1d",
+        "rev": "be239ff9f54422603b3acf5c4d87b62a0c715196",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1733963387,
-        "narHash": "sha256-jvsFZ+VbYB/hEqNuX9px8mH8xfoY4VAHZV9+VXcz/0w=",
+        "lastModified": 1737937741,
+        "narHash": "sha256-IbfaZYGn4mDJVsM8/GsPyRBLsRP8saAHvST42IJuiBk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5c0fd51259ba86b2f81fe9d97f6dc09ebc7f5cf4",
+        "rev": "5f787e9eea8708dc08ae1224a06677c27707205f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is required before `plutus` can be switched from the `cryptonite` library to `crypton`. The former is deprecated in favor of the latter which is a drop in replacement.

See https://github.com/IntersectMBO/plutus/pull/6799