### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -24,7 +24,6 @@ let
 
   hydraJobsPerSystem = {
     "x86_64-linux" = defaultHydraJobs; 
-    "x86_64-darwin" = defaultHydraJobs;
     "aarch64-linux" = defaultHydraJobs; 
     "aarch64-darwin" = defaultHydraJobs;
   };


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->

Pre-submit checklist:
- Branch
    - [x] ~~Tests are provided (if possible)~~
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] ~~Changelog fragments have been written (if appropriate)~~
    - [x] ~~Relevant tickets are mentioned in commit messages~~
    - [x] ~~Formatting, PNG optimization, etc. are updated~~
- PR
    - [x] ~~(For external contributions) Corresponding issue exists and is linked in the description~~
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
