### PR TITLE
Grant explicit permissions to bump-plutus-version workflow

### DIFF
--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build-devcontainer:
     name: Build DevContainer

--- a/.github/workflows/bump-plutus-version.yml
+++ b/.github/workflows/bump-plutus-version.yml
@@ -7,6 +7,10 @@ on:
         description: plutus Release Version (e.g. 1.26.0.0)
         required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   bump-plutus-version:
     name: Bump Plutus Version


### PR DESCRIPTION
## Summary

Adds an explicit workflow-level `permissions:` block to `.github/workflows/bump-plutus-version.yml`:

```yaml
permissions:
  contents: write
  pull-requests: write
```
